### PR TITLE
Add -i Flag to sed command 

### DIFF
--- a/content/post/a1111-webui/index.md
+++ b/content/post/a1111-webui/index.md
@@ -175,7 +175,12 @@ cd stable-diffusion-webui
 
 # remove torch from requirements.txt
 # idk if it is ok to skip
-sed '/torch/d' requirements.txt
+sed -i '/torch/d' requirements.txt
+
+# Add libraries that were removed accidentally
+echo "torchdiffeq" >> requirements.txt 
+echo "torchsde" >> requirements.txt
+echo "pytorch_lightning" >> requirements.txt
 
 pip install -r requirements.txt
 


### PR DESCRIPTION
Not using the -i flag does only log the changes to console, but it does not actually save the file with the replacement.
Also this removes every line containing the word "torch" at any position, so we echo back the lines that were removed accidentally.

See: https://manpages.ubuntu.com/manpages/trusty/en/man1/sed.1.html (search for "-i")